### PR TITLE
fix: remove unnecessary local media endpoints

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -60,12 +60,7 @@ urlpatterns = [
     path('', include('django_prometheus.urls')),   # Prometheus Monitoring
 ]
 
-# Static and media file serving fallback
+# Static file serving fallback for development
 if settings.DEBUG:
-    urlpatterns += static(settings.STATIC_URL,
-                          document_root=settings.STATIC_ROOT)
-else:
-    urlpatterns += static(settings.MEDIA_URL,
-                          document_root=settings.MEDIA_ROOT)
     urlpatterns += static(settings.STATIC_URL,
                           document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
Removed redundant media serving through Django since GCS handles it.