### PR TITLE
fix: restore media endpoints for local development

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -62,5 +62,7 @@ urlpatterns = [
 
 # Static file serving fallback for development
 if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL,
+                          document_root=settings.MEDIA_ROOT)
     urlpatterns += static(settings.STATIC_URL,
                           document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
Restores media serving endpoints exclusively in DEBUG=True so local dev mode functions correctly.