### PR TITLE
fix: entirely remove media endpoints as app lacks media files

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -62,7 +62,5 @@ urlpatterns = [
 
 # Static file serving fallback for development
 if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL,
-                          document_root=settings.MEDIA_ROOT)
     urlpatterns += static(settings.STATIC_URL,
                           document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
Completely stripped media routing fallback for dev and prod, as there are no media models in this app.