### PR TITLE
fix(frontend): Add --host flag to Vite dev script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "test": "vitest run",


### PR DESCRIPTION
Ensures the Vite dev server binds to 0.0.0.0 inside the Docker container, making the frontend accessible to the host machine.