### PR TITLE
fix(docker): Update Postgres 18 volume mount path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - trivia-local-db-data:/var/lib/postgresql/data
+      - trivia-local-db-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U trivia-prod -d postgres-core"]
       interval: 5s


### PR DESCRIPTION
Updates the container data volume mount to /var/lib/postgresql per the new Postgres 18+ configuration standard (docker-library/postgres#1259) to prevent pg_ctlcluster errors.